### PR TITLE
Parameterize the authJS to limit the edit required to get started

### DIFF
--- a/dist/js/auth.js
+++ b/dist/js/auth.js
@@ -2,15 +2,16 @@
 
 const environmentId = ''; // available on settings page of p14c admin console
 const clientId = ''; // available on connections tab of admin console
+const publicHostPort = 'localhost:5500';
 
 const scopes = 'openid profile';
 const responseType = 'token id_token';
 const acrValue = 'Single_Factor'; // Single_Factor or Multi_Factor.  Must be assigned as a Policy to your app connection 
 
 const cookieDomain = ''; // unnecessary unless using subdomains (e.g., login.example.com, help.example.com, docs.example.com).  Then use a common root (e.g., .example.com)
-const landingUrl = 'https://localhost:5500/'; // url to send the person once authentication is complete
-const logoutUrl = 'https://localhost:5500/logout/'; // whitelisted url to send a person who wants to logout
-const redirectUri = 'https://localhost:5500/login/'; // whitelisted url P14C sends the token or code to
+const landingUrl = 'https://'+publicHostPort; // url to send the person once authentication is complete
+const logoutUrl = landingUrl+'/logout/'; // whitelisted url to send a person who wants to logout
+const redirectUri = landingUrl + '/login/'; // whitelisted url P14C sends the token or code to
 
 const authUrl = 'https://auth.pingone.com';
 const apiUrl = 'https://api.pingone.com/v1';


### PR DESCRIPTION
I propose parameterizing the public host and port in an effort to reduce the number of edits required to get started and group them at the top of the file